### PR TITLE
Fixed name of gem in Usage section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ basic construct for user management and then gets out of the way.
 
 ## Usage
 
-You use `oa-identity` just like you would any other OmniAuth provider: as a
+You use `omniauth-identity` just like you would any other OmniAuth provider: as a
 Rack middleware. The basic setup for a email/password authentication would
 look something like this:
 


### PR DESCRIPTION
When setting up this gem for a recent project I attempted to use the gem name in documentation `oa-identity` to install it, but when running bundle install I found that wasn't the valid gem name.  This commit fixes the documentation to reflect the correct gem name `omniauth-identity`.
