### PR TITLE
Fixing syntax error in registration form example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,8 +83,8 @@ other fields.
     <%= form_tag '/auth/identity/register' do |f| %>
       <h1>Create an Account</h1>
       <%= text_field_tag :email %>
-      <%= password_field_tag, :password %>
-      <%= password_field_tag, :password_confirmation %>
+      <%= password_field_tag :password %>
+      <%= password_field_tag :password_confirmation %>
       <%= submit_tag %>
     <% end %>
 


### PR DESCRIPTION
In implementing a registration form I noticed that the example form includes a `,` after both the password fields which throws a syntax error.
