### PR TITLE
Make bcrypt-ruby a runtime dependency so it works out of the box

### DIFF
--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -3,13 +3,13 @@ require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '~> 1.0'
+  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
 
   gem.add_development_dependency 'maruku', '~> 0.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'
   gem.add_development_dependency 'rack-test', '~> 0.5'
   gem.add_development_dependency 'rake', '~> 0.8'
   gem.add_development_dependency 'rspec', '~> 2.7'
-  gem.add_development_dependency 'bcrypt-ruby', '~> 3.0'
   gem.add_development_dependency 'activerecord', '~> 3.1'
   gem.add_development_dependency 'mongoid'
   gem.add_development_dependency 'mongo_mapper'


### PR DESCRIPTION
As noted by Ryan Bates in the RailsCast on OmniAuth Identity it currently requires you to add both omniauth-identity and bcrypt-ruby gems to the gemfile in order to work properly. Changing the bcrypt gem to be a runtime dependency allows it to work out of the box.
