### PR TITLE
Use the auth_key specified in the model instead of the hardcoded "auth_key" string

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -112,6 +112,9 @@ use OmniAuth::Builder do
 end
 ```
 
+MyCustomClass should have an class method called #auth_key that returns
+the default ('email') or custom auth_key to use.
+
 ## Customizing Registration Failure
 
 To use your own custom registration form, create a form that POSTs to

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -14,7 +14,7 @@ module OmniAuth
           :title => (options[:title] || "Identity Verification"),
           :url => callback_path
         ) do |f|
-          f.text_field 'Login', 'auth_key'
+          f.text_field 'Login', model.auth_key
           f.password_field 'Password', 'password'
           f.html "<p align='center'><a href='#{registration_path}'>Create an Identity</a></p>"
         end.to_response 
@@ -75,7 +75,7 @@ module OmniAuth
       end
 
       def identity
-        @identity ||= model.authenticate(request['auth_key'], request['password'])
+        @identity ||= model.authenticate(request[model.auth_key], request['password'])
       end
 
       def model

--- a/spec/omniauth/identity/model_spec.rb
+++ b/spec/omniauth/identity/model_spec.rb
@@ -1,12 +1,16 @@
 require 'spec_helper'
 
-class ExampleModel
+class ClassMethodsExampleModel
+  include OmniAuth::Identity::Model
+end
+
+class InstanceMethodsExampleModel
   include OmniAuth::Identity::Model
 end
 
 describe OmniAuth::Identity::Model do
   context 'Class Methods' do
-    subject{ ExampleModel }
+    subject{ ClassMethodsExampleModel }
 
     describe '.locate' do
       it('should be abstract'){ lambda{ subject.locate('abc') }.should raise_error(NotImplementedError) }
@@ -24,10 +28,24 @@ describe OmniAuth::Identity::Model do
         subject.authenticate('blah','foo').should be_false
       end
     end
+
+    describe '.auth_key' do
+      it 'should default to email if called with false' do
+        subject.auth_key(false).should == 'email'
+      end
+
+      it 'should default to email if called with empty string' do
+        subject.auth_key('').should == 'email'
+      end
+
+      it 'should save the custom auth_key' do
+        subject.auth_key('method_x').should == 'method_x'
+      end
+    end
   end
 
   context 'Instance Methods' do
-    subject{ ExampleModel.new }
+    subject{ InstanceMethodsExampleModel.new }
 
     describe '#authenticate' do
       it('should be abstract'){ lambda{ subject.authenticate('abc') }.should raise_error(NotImplementedError) }

--- a/spec/omniauth/strategies/identity_spec.rb
+++ b/spec/omniauth/strategies/identity_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
-class MockIdentity; end
+class MockIdentity
+  def self.auth_key; :email end
+end
 
 describe OmniAuth::Strategies::Identity do
   attr_accessor :app
@@ -42,7 +44,7 @@ describe OmniAuth::Strategies::Identity do
     context 'with valid credentials' do
       before do
         MockIdentity.should_receive('authenticate').with('john','awesome').and_return(user)
-        post '/auth/identity/callback', :auth_key => 'john', :password => 'awesome'
+        post '/auth/identity/callback', MockIdentity.auth_key => 'john', :password => 'awesome'
       end
 
       it 'should populate the auth hash' do
@@ -62,7 +64,7 @@ describe OmniAuth::Strategies::Identity do
       before do
         OmniAuth.config.on_failure = lambda{|env| [401, {}, [env['omniauth.error.type'].inspect]]}
         MockIdentity.should_receive(:authenticate).with('wrong','login').and_return(false)
-        post '/auth/identity/callback', :auth_key => 'wrong', :password => 'login'
+        post '/auth/identity/callback', MockIdentity.auth_key => 'wrong', :password => 'login'
       end
 
       it 'should fail with :invalid_credentials' do


### PR DESCRIPTION
This patch enables using only email/username fields instead of auth_key
in the registration/login forms (as spotted in
http://asciicasts.com/episodes/304-omniauth-identity).

With it omniauth-identity integration becomes a bit easier.
