### PR TITLE
Add hooks for the login and register phases

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -35,11 +35,7 @@ module OmniAuth
       def other_phase
         if on_registration_path?
           if request.get?
-            if options[:on_registration]
-              options[:on_registration].call(self.env)
-            else
-              registration_form
-            end
+            registration_form
           elsif request.post?
             registration_phase
           end
@@ -49,13 +45,17 @@ module OmniAuth
       end
 
       def registration_form
-        OmniAuth::Form.build(:title => 'Register Identity') do |f|
-          options[:fields].each do |field|
-            f.text_field field.to_s.capitalize, field.to_s
-          end
-          f.password_field 'Password', 'password'
-          f.password_field 'Confirm Password', 'password_confirmation'
-        end.to_response
+        if options[:on_registration]
+          options[:on_registration].call(self.env)
+        else
+          OmniAuth::Form.build(:title => 'Register Identity') do |f|
+            options[:fields].each do |field|
+              f.text_field field.to_s.capitalize, field.to_s
+            end
+            f.password_field 'Password', 'password'
+            f.password_field 'Confirm Password', 'password_confirmation'
+          end.to_response
+        end
       end
 
       def registration_phase


### PR DESCRIPTION
I needed to add an option for overriding the /auth/identity and /auth/identity/register routes so I can call my own action on those routes. I used the same pattern already in place for the on_failed_registration option.

```

  provider :identity,
    :fields => [:nickname],
    :locate_conditions => lambda { |req| { model.auth_key => req['nickname']} },
    :on_login => SessionController.action(:login),
    :on_register => SessionController.action(:register),
    :on_failed_registration => SessionController.action(:failure)

```
