### PR TITLE
Fixing bug in locate_conditions

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -86,11 +86,11 @@ module OmniAuth
       end
 
       def identity
-        if options.locate_conditions.is_a? Proc
-          conditions = instance_exec(request, &options.locate_conditions)
+        if options[:locate_conditions].is_a? Proc
+          conditions = instance_exec(request, &options[:locate_conditions])
           conditions.to_hash
         else
-          conditions = options.locate_conditions.to_hash
+          conditions = options[:locate_conditions].to_hash
         end
         @identity ||= model.authenticate(conditions, request['password'] )
       end


### PR DESCRIPTION
The "locate_conditions" option was being accessed using dot notation, but it should be accessed as a hash. Currently, the locate_conditions method is never called.
