### PR TITLE
Adds support for the Sequel ORM.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
+    sequel (3.46.0)
     simplecov (0.5.4)
       multi_json (~> 1.0.3)
       simplecov-html (~> 0.5.3)
@@ -152,4 +153,5 @@ DEPENDENCIES
   rake (~> 0.8)
   rb-fsevent
   rspec (~> 2.7)
+  sequel
   simplecov (~> 0.4)

--- a/README.markdown
+++ b/README.markdown
@@ -113,6 +113,21 @@ class Identity
 end
 ```
 
+### Sequel
+
+Include the `OmniAuth::Identity::Models::Sequel` mixin and and provide 
+fields in the database for all of the fields you are using.
+
+```ruby
+class Identity
+	include OmniAuth::Identity::Models::Sequel
+
+  attr_accessor :password_confirmation
+
+  # Add whatever you like!
+end
+```
+
 Once you've got an Identity persistence model and the strategy up and
 running, you can point users to `/auth/identity` and it will request
 that they log in or give them the opportunity to sign up for an account.

--- a/lib/omniauth/identity.rb
+++ b/lib/omniauth/identity.rb
@@ -14,6 +14,7 @@ module OmniAuth
       autoload :Mongoid,           'omniauth/identity/models/mongoid'
       autoload :DataMapper,        'omniauth/identity/models/data_mapper'
       autoload :CouchPotatoModule, 'omniauth/identity/models/couch_potato'
+      autoload :Sequel,            'omniauth/identity/models/sequel'
     end
   end
 end

--- a/lib/omniauth/identity/models/sequel.rb
+++ b/lib/omniauth/identity/models/sequel.rb
@@ -1,0 +1,31 @@
+require 'sequel'
+
+module OmniAuth
+  module Identity
+    module Models
+      module Sequel
+        def self.included(base)
+          base.class_eval do
+            include OmniAuth::Identity::Model
+            include OmniAuth::Identity::SecurePassword
+
+            # has_secure_password assumes the validators are class-level and
+            # named in the active record convention, so enable them here.
+            plugin :validation_class_methods
+
+            has_secure_password
+
+            def self.auth_key=(key)
+              super
+              validates_uniqueness_of :key
+            end
+
+            def self.locate(search_hash)
+              first(search_hash)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'datamapper'
   gem.add_development_dependency 'bson_ext'
   gem.add_development_dependency 'couch_potato'
+  gem.add_development_dependency 'sequel'
 
   gem.name = 'omniauth-identity'
   gem.version = OmniAuth::Identity::VERSION

--- a/spec/omniauth/identity/models/sequel_spec.rb
+++ b/spec/omniauth/identity/models/sequel_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe(OmniAuth::Identity::Models::Sequel, :db => true) do
+  # One nuisance w/ Sequel is that it needs a database connection prior to 
+  # defining the models - this is true even if we aren't actually hitting
+  # the database (as is the case in this test). So we need to create a mock
+  # database here.
+  db = Sequel.mock(:fetch=>{:id => 1, :x => 1}, :numrows=>1, :autoid=>proc{|sql| 10})
+  def db.schema(*) [[:id, {:primary_key=>true}]] end
+  def db.reset() sqls end
+  Sequel::Model.db = MODEL_DB = db
+
+  class SequelTestIdentity < Sequel::Model
+    include OmniAuth::Identity::Models::Sequel
+  end
+
+  before :all do
+    @resource = SequelTestIdentity.new
+  end
+
+  it 'should delegate locate to the all query method' do
+    SequelTestIdentity.should_receive(:first).with('ham_sandwich' => 'open faced', 'category' => 'sandwiches').and_return('wakka')
+    SequelTestIdentity.locate('ham_sandwich' => 'open faced', 'category' => 'sandwiches').should == 'wakka'
+  end
+end


### PR DESCRIPTION
- New OmniAuth::Identity::Models::Sequel mixin
- Corresponding spec for the new mixin
- Updated gemspec to include sequel.
- Updated README.
