### PR TITLE
Update bcrypt-ruby dependency to be compatible with Rails 4

### DIFF
--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '~> 1.0'
-  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  gem.add_runtime_dependency 'bcrypt-ruby', '>= 3.0.0'
 
   gem.add_development_dependency 'maruku', '~> 0.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
bcrypt-ruby 3.1.x is required for has_secure_password, but the gemspec does not allow for that particular version (I thought it would at first though)
