### PR TITLE
Fix mongoid spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /pkg
 /doc
 
+.bundle

--- a/spec/omniauth/identity/models/mongoid_spec.rb
+++ b/spec/omniauth/identity/models/mongoid_spec.rb
@@ -7,6 +7,8 @@ describe(OmniAuth::Identity::Models::Mongoid, :db => true) do
     auth_key :ham_sandwich
   end
 
+  Mongoid.load! File.expand_path('../../../../support/mongoid.yml', __FILE__), 'test'
+
   it 'should delegate locate to the where query method' do
     MongoidTestIdentity.should_receive(:where).with('ham_sandwich' => 'open faced', 'category' => 'sandwiches').and_return(['wakka'])
     MongoidTestIdentity.locate('ham_sandwich' => 'open faced', 'category' => 'sandwiches').should == 'wakka'

--- a/spec/support/mongoid.yml
+++ b/spec/support/mongoid.yml
@@ -1,0 +1,6 @@
+test:
+  sessions:
+    default:
+      database: omniauth_identity_test
+      hosts:
+        - localhost:27017


### PR DESCRIPTION
`mongoid_spec.rb` needs a correct configuration to run, or you'll see this error:

```
  1) OmniAuth::Identity::Models::Mongoid should not use STI rules for its collection name
     Failure/Error: MongoidTestIdentity.collection.name.should == 'mongoid_test_identities'
     Mongoid::Errors::NoSessionConfig:

       Problem:
         No configuration could be found for a session named 'default'.
       Summary:
         When attempting to create the new session, Mongoid could not find a session configuration for the name: 'default'. This is necessary in order to know the host, port, and options needed to connect.
       Resolution:
         Double check your mongoid.yml to make sure under the sessions key that a configuration exists for 'default'. If you have set the configuration programatically, ensure that 'default' exists in the configuration hash.
     # ./spec/omniauth/identity/models/mongoid_spec.rb:16:in `block (2 levels) in <top (required)>'
```
