### PR TITLE
Fixed warning that `bcrypt-ruby` has been renamed.

### DIFF
--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '~> 1.0'
-  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  gem.add_runtime_dependency 'bcrypt', '~> 3.0'
 
   gem.add_development_dependency 'maruku', '~> 0.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
Updated Gemfile to fix:

> The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your dependencies accordingly.
