### PR TITLE
Adds provider information when used with multiple providers

### DIFF
--- a/lib/omniauth-identity/version.rb
+++ b/lib/omniauth-identity/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Identity
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/lib/omniauth/identity/models/active_record.rb
+++ b/lib/omniauth/identity/models/active_record.rb
@@ -16,6 +16,9 @@ module OmniAuth
         end
 
         def self.locate(search_hash)
+          if self.column_names.include? 'provider'
+            search_hash[:provider] = 'identity'
+          end
           where(search_hash).first
         end
       end

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -60,6 +60,9 @@ module OmniAuth
 
       def registration_phase
         attributes = (options[:fields] + [:password, :password_confirmation]).inject({}){|h,k| h[k] = request[k.to_s]; h}
+        if model.column_names.include? 'provider'
+          attributes[:provider] = 'identity'
+        end
         @identity = model.create(attributes)
         if @identity.persisted?
           env['PATH_INFO'] = callback_path

--- a/omniauth-identity.gemspec
+++ b/omniauth-identity.gemspec
@@ -2,20 +2,20 @@
 require File.dirname(__FILE__) + '/lib/omniauth-identity/version'
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'omniauth', '~> 1.0'
-  gem.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  gem.add_runtime_dependency 'omniauth', '~> 1.2'
+  gem.add_runtime_dependency 'bcrypt', '~> 3.1'
 
-  gem.add_development_dependency 'maruku', '~> 0.6'
-  gem.add_development_dependency 'simplecov', '~> 0.4'
-  gem.add_development_dependency 'rack-test', '~> 0.5'
-  gem.add_development_dependency 'rake', '~> 0.8'
-  gem.add_development_dependency 'rspec', '~> 2.7'
-  gem.add_development_dependency 'activerecord', '~> 3.1'
-  gem.add_development_dependency 'mongoid'
-  gem.add_development_dependency 'mongo_mapper'
-  gem.add_development_dependency 'datamapper'
-  gem.add_development_dependency 'bson_ext'
-  gem.add_development_dependency 'couch_potato'
+  gem.add_development_dependency 'maruku', '~> 0.7'
+  gem.add_development_dependency 'simplecov', '~> 0.10'
+  gem.add_development_dependency 'rack-test', '~> 0.6'
+  gem.add_development_dependency 'rake', '~> 10.4'
+  gem.add_development_dependency 'rspec', '~> 3.2'
+  gem.add_development_dependency 'activerecord', '~> 4.2'
+  gem.add_development_dependency 'mongoid', '~> 4.0'
+  gem.add_development_dependency 'mongo_mapper', '~> 0.13'
+  gem.add_development_dependency 'datamapper', '~> 1.2'
+  gem.add_development_dependency 'bson_ext', '~> 1.12'
+  gem.add_development_dependency 'couch_potato', '~> 1.4'
 
   gem.name = 'omniauth-identity'
   gem.version = OmniAuth::Identity::VERSION


### PR DESCRIPTION
Following the OmniAuth guidance for managing multiple authentication
providers (http://git.io/jBOJFw), if the `provider` column exists on
the model then it will be populated with 'identity' and used to
find the correct record during authentication.

This resolves intridea/omniauth-identity#69
