### PR TITLE
added test for and implementation of validation error message

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -44,11 +44,15 @@ module OmniAuth
         end
       end
 
-      def registration_form
+      def registration_form(validation_message = nil)
         if options[:on_registration]
           options[:on_registration].call(self.env)
         else
           OmniAuth::Form.build(:title => 'Register Identity') do |f|
+            if validation_message
+              f.html "<p style='color:red'>#{validation_message}</p>"
+            end
+
             options[:fields].each do |field|
               f.text_field field.to_s.capitalize, field.to_s
             end
@@ -69,7 +73,8 @@ module OmniAuth
             self.env['omniauth.identity'] = @identity
             options[:on_failed_registration].call(self.env)
           else
-            registration_form
+            validation_message = "One or more fields were invalid"
+            registration_form(validation_message)
           end
         end
       end

--- a/spec/omniauth/strategies/identity_spec.rb
+++ b/spec/omniauth/strategies/identity_spec.rb
@@ -113,7 +113,7 @@ describe OmniAuth::Strategies::Identity do
 
     context 'with invalid identity' do
       let(:properties) { {
-        :name => 'Awesome Dude', 
+        :name => 'Awesome Dude',
         :email => 'awesome@example.com',
         :password => 'NOT',
         :password_confirmation => 'MATCHING'
@@ -127,6 +127,7 @@ describe OmniAuth::Strategies::Identity do
         it 'should show registration form' do
           post '/auth/identity/register', properties
           last_response.body.should be_include("Register Identity")
+          last_response.body.should be_include("One or more fields were invalid")
         end
       end
 


### PR DESCRIPTION
As commented on in RailsCasts episode 304, it was confusing for a developer (and user) if invalid attributes were erroneously added into the Identity Registration form and submitted. All that happened was that the form persisted and the entered values disappeared. 

http://railscasts.com/episodes/304-omniauth-identity?autoplay=true

Added in a default generic error code to the form but kept logic simple in order to continue to encourage developers to create custom forms. 
