### PR TITLE
Added Email to the title of the Login field

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -20,7 +20,7 @@ module OmniAuth
             :title => (options[:title] || "Identity Verification"),
             :url => callback_path
           ) do |f|
-            f.text_field 'Login', 'auth_key'
+            f.text_field 'Login Email', 'auth_key'
             f.password_field 'Password', 'password'
             f.html "<p align='center'><a href='#{registration_path}'>Create an Identity</a></p>"
           end.to_response


### PR DESCRIPTION
As mentioned in RailsCasts Episode 304, having just "Login" was confusing
Changing to Login Email should allow users and devs to know what belongs in
the text field.

http://railscasts.com/episodes/304-omniauth-identity?autoplay=true
