### PR TITLE
⚠️ instance variable @auth_key not initialized

### DIFF
--- a/lib/omniauth/identity/model.rb
+++ b/lib/omniauth/identity/model.rb
@@ -36,7 +36,7 @@ module OmniAuth
         # @return [String] The method name.
         def auth_key(method = false)
           @auth_key = method.to_s unless method == false
-          @auth_key = nil if @auth_key == ''
+          @auth_key = nil if !defined?(@auth_key) || @auth_key == ''
 
           @auth_key || 'email'
         end


### PR DESCRIPTION
This patch fixes a Ruby warning.
The patch indeed looks a little bit messy, but this code is the smallest and simplest patch that I could come up with.
