### PR TITLE
The RSpec nested formatter has been renamed to documentation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format=nested
+--format=documentation
 --colour


### PR DESCRIPTION
The "nested" formatter is no more available since [this commit](https://github.com/rspec/rspec-core/commit/b8d55efcf4b6b5e1656b9c2a4095c6dd3054ea03).
