### PR TITLE
Replace deprecated usage of Request[] with request.params[]

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -71,7 +71,7 @@ module OmniAuth
 
       def registration_phase
         attributes = (options[:fields] + DEFAULT_REGISTRATION_FIELDS).each_with_object({}) do |k, h|
-          h[k] = request[k.to_s]
+          h[k] = request.params[k.to_s]
         end
         if model.respond_to?(:column_names) && model.column_names.include?('provider')
           attributes.reverse_merge!(provider: 'identity')
@@ -110,7 +110,7 @@ module OmniAuth
         else
           conditions = options[:locate_conditions].to_hash
         end
-        @identity ||= model.authenticate(conditions, request['password'])
+        @identity ||= model.authenticate(conditions, request.params['password'])
       end
 
       def model


### PR DESCRIPTION
In Rack 3.0.0.beta1, `Request[]` [was deprecated](https://github.com/rack/rack/blob/main/CHANGELOG.md#300beta1---2022-08-08) and prints the following message to the console when used:

> Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead

This PR replaces the use of `Request[]` with `Request.params[]` per the recommendation of the console message.