### PR TITLE
Fix: broken registration_path when SCRIPT_NAME is not empty string

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -96,7 +96,7 @@ module OmniAuth
       info { identity.info }
 
       def registration_path
-        options[:registration_path] || "#{path_prefix}/#{name}/register"
+        options[:registration_path] || "#{script_name}#{path_prefix}/#{name}/register"
       end
 
       def on_registration_path?
@@ -169,7 +169,7 @@ module OmniAuth
 
       def registration_result
         if @identity.persisted?
-          env['PATH_INFO'] = callback_path
+          env['PATH_INFO'] = "#{path_prefix}/#{name}/callback"
           callback_phase
         else
           registration_failure(options[:registration_failure_message])


### PR DESCRIPTION
The registration_path must include the SCRIPT_NAME when it exists to allow requests to be seen as properly `on_path?` and to be routed to the correct rack app. Additionally, the private method `#registration_result` must not replace the PATH_INFO with `#callback_path` as `OmniAuth::Strategy#callback_path` already includes the SCRIPT_PATH leading to the SCRIPT_PATH portion being duplicated when registration completes and is forwarded to the callback endpoint.

Spec tests added to test all combinations of default and optional values of SCRIPT_PATH, OmniAuth::Strategy.path_prefix, and Identity.name.

see #119 