### PR TITLE
Use req.params[] instead of req[], which was removed in rack 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The default value is:
 ```ruby
 use OmniAuth::Builder do
   provider :identity,
-           locate_conditions: ->(req) { { model.auth_key => req['auth_key'] } }
+           locate_conditions: ->(req) { { model.auth_key => req.params['auth_key'] } }
     # ...
 end
 ```
@@ -270,7 +270,7 @@ option :on_login, nil               # See #request_phase
 option :on_validation, nil          # See #registration_phase
 option :on_registration, nil        # See #registration_phase
 option :on_failed_registration, nil # See #registration_phase
-option :locate_conditions, ->(req) { { model.auth_key => req['auth_key'] } }
+option :locate_conditions, ->(req) { { model.auth_key => req.params['auth_key'] } }
 ```
 
 Please contribute some documentation if you have the gumption!  The maintainer's time is limited, and sometimes the authors of PRs with new options don't update the _this_ readme. 😭

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -19,7 +19,7 @@ module OmniAuth
       option :on_validation, nil          # See #registration_phase
       option :on_registration, nil        # See #registration_phase
       option :on_failed_registration, nil # See #registration_phase
-      option :locate_conditions, ->(req) { { model.auth_key => req['auth_key'] } }
+      option :locate_conditions, ->(req) { { model.auth_key => req.params['auth_key'] } }
       option :create_identity_link_text, 'Create an Identity'
       option :registration_failure_message, 'One or more fields were invalid'
       option :validation_failure_message, 'Validation failed'
@@ -110,7 +110,7 @@ module OmniAuth
         else
           conditions = options[:locate_conditions].to_hash
         end
-        @identity ||= model.authenticate(conditions, request['password'])
+        @identity ||= model.authenticate(conditions, request.params['password'])
       end
 
       def model

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -71,7 +71,7 @@ module OmniAuth
 
       def registration_phase
         attributes = (options[:fields] + DEFAULT_REGISTRATION_FIELDS).each_with_object({}) do |k, h|
-          h[k] = request[k.to_s]
+          h[k] = request.params[k.to_s]
         end
         if model.respond_to?(:column_names) && model.column_names.include?('provider')
           attributes.reverse_merge!(provider: 'identity')

--- a/spec/omniauth/strategies/identity_spec.rb
+++ b/spec/omniauth/strategies/identity_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe OmniAuth::Strategies::Identity, sqlite3: true do
     context 'with auth scopes' do
       let(:identity_options) do
         { model: anon_ar, locate_conditions: lambda { |req|
-                                               { model.auth_key => req['auth_key'], 'user_type' => 'admin' }
+                                               { model.auth_key => req.params['auth_key'], 'user_type' => 'admin' }
                                              } }
       end
 


### PR DESCRIPTION
use req.params[] instead of req[], which was removed in rack 3.1.0
https://github.com/rack/rack/pull/2183

the omniauth-identity worked with the following warning in rack 3.0.x
```
warning: Request#[] is deprecated and will be removed in a future version of Rack
```
However, omniauth-identity no longer works with an error in rack 3.1.x and needs to be fixed.

See also #116