### PR TITLE
Refactor for readability in #identity method in OmniAuth::Strategies::Identity

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -104,12 +104,9 @@ module OmniAuth
       end
 
       def identity
-        if options[:locate_conditions].is_a? Proc
-          conditions = instance_exec(request, &options[:locate_conditions])
-          conditions.to_hash
-        else
-          conditions = options[:locate_conditions].to_hash
-        end
+        conditions = options[:locate_conditions]
+        conditions = conditions.is_a?(Proc) ? instance_exec(request, &conditions).to_hash : conditions.to_hash
+
         @identity ||= model.authenticate(conditions, request['password'])
       end
 


### PR DESCRIPTION
This PR improves readability of the `identity` method in `OmniAuth::Strategies::Identity`

1. `conditions.to_hash` is redundant, since `to_hash` doesn't change the caller, and the return of that call is never stored anywhere
2. instead of having `options[:locate_conditions]` three times, it is now stored in a variable that is used below, which in turn allows for a ternary operator instead of an `if-else`

